### PR TITLE
harmony branch of uglify renamed to uglify-es

### DIFF
--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -11,6 +11,8 @@ var ADD_CONFIG_LOCAL = false;
 module.exports = function(grunt) {
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
+  grunt.loadNpmTasks('grunt-contrib-uglify-es');
+
   // grunt.loadNpmTasks('grunt-contrib-less');
   // Automatically load required Grunt tasks
   require('jit-grunt')(grunt, {

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-cssmin": "^1.0.2",
     "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-less": "^1.4.1",
-    "grunt-contrib-uglify": "git://github.com/gruntjs/grunt-contrib-uglify.git#harmony",
+    "grunt-contrib-uglify-es": "git://github.com/gruntjs/grunt-contrib-uglify.git#harmony",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^2.1.2",
     "grunt-postcss": "^0.5.5",


### PR DESCRIPTION
## Motivation

We are using the harmony branch of `grunt-contrib-uglify` in the ui. The name of the package was changed to `grunt-contrib-uglify-es` (only in this branch: https://github.com/gruntjs/grunt-contrib-uglify/commit/ccb95a70cad6a4e9e902d3bd5d0e38a4de09a1e1) and it won't install at the moment. 

## Description
The changes in this PR make the `grunt build` task work with uglify-es.

## Progress

- [x] Finished task

## Additional Notes

Also relevant: https://github.com/gruntjs/grunt-contrib-uglify/issues/499
(a separate packate `grunt-contrib-uglify-es` will be available soon)