### PR TITLE
Remove unneeded oc install information

### DIFF
--- a/installer/vars/mobile-control-panel.yml
+++ b/installer/vars/mobile-control-panel.yml
@@ -1,9 +1,3 @@
 ---
-
 force_oc_link: yes
-oc_ver: v3.7.0-rc.0
-oc_sha: 'e92d5c5'
-oc_checksums:
-  linux-64bit: sha256:e35e53b42a00e4d04305ec55c94b623135d3ac236c999c00765703161da23769
-  mac: sha256:0f1ec8ad4e84a207e54d526c27daa73bd066f75f14d8f735377132da04acb959
 wildcard_dns_host: nip.io


### PR DESCRIPTION
## Motivation

By default oc 3.7.0 will be installed. However we are overwriting
this information with an out-of-date data structure containing information
such as the oc version and a checksum.. This is resulting
in any users who do not already have oc cached locally or installed
to experience an error with trying to access the data structure.

This change removes the overridden data structure so that the default
data structure can be used and install oc 3.7.0.

Resolves https://github.com/aerogear/mobile-core/issues/1

## Description
Remove a no longer needed variable override.

## Progress

- [x] Remove variables


  