### PR TITLE
Add global dockerhub variables

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -178,6 +178,10 @@ function run_installer() {
     read -p "DockerHub Password: " dockerhub_password
     stty echo
 
+    ## If empty use global system variables
+    dockerhub_username=${dockerhub_username:-$DOCKERHUB_USERNAME}
+    dockerhub_password=${dockerhub_password:-$DOCKERHUB_PASSWORD}
+
     echo -e "\nChecking DockerHub credentials are valid...\n"
 
     curl --fail -u ${dockerhub_username}:${dockerhub_password} https://cloud.docker.com/api/app/v1/service/ &> /dev/null

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -173,9 +173,9 @@ function run_installer() {
   while [ $docker_credentials -eq 0 ];
   do
     docker_credentials=1
-    read -p "DockerHub Username: " dockerhub_username
+    read -p "DockerHub Username (Defaults to DOCKERHUB_USERNAME env var): " dockerhub_username
     stty -echo
-    read -p "DockerHub Password: " dockerhub_password
+    read -p "DockerHub Password (Defaults to DOCKERHUB_PASSWORD env var): " dockerhub_password
     stty echo
 
     ## If empty use global system variables


### PR DESCRIPTION
## Motivation

Ansible installer is required to run every time we need to start new mcp server. Every time users will need to pass their own password. This change will use globally defined username and password if user will skip this fields

## Progress

- [x] Implementation
- [x] Tests


