### PR TITLE
Update ansible service  broker versions

### DIFF
--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -53,7 +53,7 @@ oc process -f "${TEMPLATE_LOCAL}" \
 -p ETCD_TRUSTED_CA="$ETCD_CA_CERT" \
 -p BROKER_CLIENT_CERT="$BROKER_CLIENT_CERT" \
 -p BROKER_CLIENT_KEY="$BROKER_CLIENT_KEY" \
--p NAMESPACE=ansible-service-broker 
+-p NAMESPACE=ansible-service-broker \
 -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" \
 ${TEMPLATE_VARS} | oc create -f -
 

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -16,7 +16,7 @@ function finish {
 
 trap 'finish' EXIT
 
-readonly TEMPLATE_VERSION="71e6a73cfa314d183f73e37eae3050c5ebfe994b"
+readonly TEMPLATE_VERSION="89f05ffdd7c525329ea9a17780e996702cac1619"
 readonly TEMPLATE_URL="https://raw.githubusercontent.com/openshift/ansible-service-broker/${TEMPLATE_VERSION}/templates/deploy-ansible-service-broker.template.yaml"
 readonly TEMPLATE_LOCAL="/tmp/deploy-ansible-service-broker.template.yaml"
 readonly TEMPLATE_VARS="-p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{ index .data "service-ca.crt" }}{{end}}{{"\n"}}{{end}}' | tail -n 1)"
@@ -30,7 +30,7 @@ oc process -f "${TEMPLATE_LOCAL}" \
 -p DOCKERHUB_USER="$( echo ${DOCKERHUB_USER} | base64 )" \
 -p DOCKERHUB_PASS="$( echo ${DOCKERHUB_PASS} | base64 )" \
 -p DOCKERHUB_ORG="${DOCKERHUB_ORG}" \
--p BROKER_IMAGE="ansibleplaybookbundle/origin-ansible-service-broker:sprint139.1" \
+-p BROKER_IMAGE="ansibleplaybookbundle/origin-ansible-service-broker:sprint142" \
 -p ENABLE_BASIC_AUTH="false" \
 -p SANDBOX_ROLE="admin" \
 -p ROUTING_SUFFIX="192.168.37.1.${WILDCARD_DNS}" \

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -54,6 +54,7 @@ oc process -f "${TEMPLATE_LOCAL}" \
 -p BROKER_CLIENT_CERT="$BROKER_CLIENT_CERT" \
 -p BROKER_CLIENT_KEY="$BROKER_CLIENT_KEY" \
 -p NAMESPACE=ansible-service-broker \
+-p AUTO_ESCALATE="true" \
 -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" \
 ${TEMPLATE_VARS} | oc create -f -
 


### PR DESCRIPTION
## Motivation

I had experienced problems with ansible broker when using version provided by install script. 
It looks like team fixed couple issues and recent release version has change done by @matzew 
https://github.com/openshift/ansible-service-broker/pull/601

See tags: https://hub.docker.com/r/ansibleplaybookbundle/origin-ansible-service-broker/tags/

I have been using this today and it seems to work. I might miss some details about this so feel free to close this PR. Sharing this for wider group as this may help you guys to resolve problems with push (when you use latest abp). 

ping @pb82 @maleck13 @matzew @aidenkeating 
  