### PR TITLE
Aerogear 1823 - Implement deprovision task for ansible service broker

### DIFF
--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -6,3 +6,4 @@ dockerhost: docker.io
 launch_apb_on_bind: true
 skip_apb: 
 apb_sync: false
+ansible-service-broker: ansible-service-broker

--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -6,4 +6,3 @@ dockerhost: docker.io
 launch_apb_on_bind: true
 skip_apb: 
 apb_sync: false
-ansible-service-broker: ansible-service-broker

--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -6,3 +6,4 @@ dockerhost: docker.io
 launch_apb_on_bind: true
 skip_apb: 
 apb_sync: false
+ansible_service_broker_namespace: ansible-service-broker

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -38,7 +38,7 @@ BROKER_CLIENT_KEY=$(cat /tmp/etcd-cert/MyClient1.key | base64)
 curl -s ${TEMPLATE_URL} > "${TEMPLATE_LOCAL}"
 
 oc process -f "${TEMPLATE_LOCAL}" \
--n ansible-service-broker \
+-n {{ ansible_service_broker }} \
 -p DOCKERHUB_USER="$( echo ${DOCKERHUB_USER} | base64 )" \
 -p DOCKERHUB_PASS="$( echo ${DOCKERHUB_PASS} | base64 )" \
 -p DOCKERHUB_ORG="${DOCKERHUB_ORG}" \

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -7,6 +7,7 @@ readonly DOCKERHUB_ORG="${3}"
 readonly LAUNCH_APB_ON_BIND="${4}"
 readonly TAG="${5}"
 readonly WILDCARD_DNS="${6}"
+readonly ANSIBLE_SERVICE_BROKER_NAMESPACE="${7}"
 
 echo "starting install of OpenShift Ansible Broker (OAB)"
 
@@ -38,7 +39,7 @@ BROKER_CLIENT_KEY=$(cat /tmp/etcd-cert/MyClient1.key | base64)
 curl -s ${TEMPLATE_URL} > "${TEMPLATE_LOCAL}"
 
 oc process -f "${TEMPLATE_LOCAL}" \
--n ansible-service-broker \
+-n ${ANSIBLE_SERVICE_BROKER_NAMESPACE} \
 -p DOCKERHUB_USER="$( echo ${DOCKERHUB_USER} | base64 )" \
 -p DOCKERHUB_PASS="$( echo ${DOCKERHUB_PASS} | base64 )" \
 -p DOCKERHUB_ORG="${DOCKERHUB_ORG}" \
@@ -53,7 +54,7 @@ oc process -f "${TEMPLATE_LOCAL}" \
 -p ETCD_TRUSTED_CA="$ETCD_CA_CERT" \
 -p BROKER_CLIENT_CERT="$BROKER_CLIENT_CERT" \
 -p BROKER_CLIENT_KEY="$BROKER_CLIENT_KEY" \
--p NAMESPACE=ansible-service-broker \
+-p NAMESPACE=${ANSIBLE_SERVICE_BROKER_NAMESPACE} \
 -p AUTO_ESCALATE="true" \
 -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" \
 ${TEMPLATE_VARS} | oc create -f -

--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -38,7 +38,7 @@ BROKER_CLIENT_KEY=$(cat /tmp/etcd-cert/MyClient1.key | base64)
 curl -s ${TEMPLATE_URL} > "${TEMPLATE_LOCAL}"
 
 oc process -f "${TEMPLATE_LOCAL}" \
--n {{ ansible_service_broker }} \
+-n ansible-service-broker \
 -p DOCKERHUB_USER="$( echo ${DOCKERHUB_USER} | base64 )" \
 -p DOCKERHUB_PASS="$( echo ${DOCKERHUB_PASS} | base64 )" \
 -p DOCKERHUB_ORG="${DOCKERHUB_ORG}" \

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -28,10 +28,6 @@
     - apb_sync is defined
     - apb_sync
 
-- name: Get projects
-  shell: "oc get projects"
-  register: all_projects
-
 - block:
   - name: Ensure OpenShift Ansible Broker (OAB) install script is on host
     copy:
@@ -56,7 +52,6 @@
   - dockerhub_org != ''
   - launch_apb_on_bind is defined
   - launch_apb_on_bind != ''
-  - "'ansible-service-broker' not in all_projects.stdout"
   # - oc_get_broker.stderr.find('NotFound') > -1
 
 - name: Ensure oc cluster is up

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -28,6 +28,24 @@
     - apb_sync is defined
     - apb_sync
 
+- name: Check If OpenShift Ansible Broker Is Installed
+  shell: oc get namespace "{{ ansible_service_broker_namespace }}"
+  register: asb_namespace
+  failed_when: false
+  no_log: True
+
+- name: Ensure OpenShift Ansible Broker Is Deprovisioned
+  shell: >
+      oc delete clusterrolebinding asb &&
+      oc delete clusterrolebinding asb-auth-bind &&
+      oc delete clusterrolebinding ansibleservicebroker-client &&
+      oc delete clusterrole asb-auth &&
+      oc delete clusterrole access-asb-role &&
+      oc delete clusterservicebroker ansible-service-broker
+  when: "'not found' in asb_namespace.stderr"
+  failed_when: false
+  no_log: True
+
 - block:
   - name: Ensure OpenShift Ansible Broker (OAB) install script is on host
     copy:
@@ -52,6 +70,7 @@
   - dockerhub_org != ''
   - launch_apb_on_bind is defined
   - launch_apb_on_bind != ''
+  - "'not found' in asb_namespace.stderr"
   # - oc_get_broker.stderr.find('NotFound') > -1
 
 - name: Ensure oc cluster is up

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -40,7 +40,7 @@
       mode: u+x
 
   - name: Execute OpenShift Ansible Broker (OAB) provision script
-    shell: bash -e /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}" "{{ dockerhub_org }}" "{{ launch_apb_on_bind }}" "{{dockerhub_tag}}" "{{ wildcard_dns_host }}"
+    shell: bash -e /tmp/provision-ansible-service-broker.sh "{{ dockerhub_username }}" "{{ dockerhub_password }}" "{{ dockerhub_org }}" "{{ launch_apb_on_bind }}" "{{dockerhub_tag}}" "{{ wildcard_dns_host }}" "{{ ansible_service_broker_namespace }}"
   when:
   - dockerhub_tag is defined
   - dockerhub_tag != ''

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -28,6 +28,10 @@
     - apb_sync is defined
     - apb_sync
 
+- name: Get projects
+  shell: "oc get projects"
+  register: all_projects
+
 - block:
   - name: Ensure OpenShift Ansible Broker (OAB) install script is on host
     copy:
@@ -52,6 +56,7 @@
   - dockerhub_org != ''
   - launch_apb_on_bind is defined
   - launch_apb_on_bind != ''
+  - "'ansible-service-broker' not in all_projects.stdout"
   # - oc_get_broker.stderr.find('NotFound') > -1
 
 - name: Ensure oc cluster is up

--- a/installer/roles/setup-openshift-admin-user/tasks/main.yml
+++ b/installer/roles/setup-openshift-admin-user/tasks/main.yml
@@ -5,8 +5,13 @@
   shell: "oc login -u system:admin"
   register: oc_system_admin_login
 
+- name: Get all users
+  shell: "oc get user"
+  register: all_users
+
 - name: Create admin user
   shell: "oc create user {{ user_name }}"
+  when: "user_name not in all_users.stdout"
   register: oc_create_user
 
 - name: Give admin user permissions

--- a/installer/roles/setup-openshift-admin-user/tasks/main.yml
+++ b/installer/roles/setup-openshift-admin-user/tasks/main.yml
@@ -3,7 +3,6 @@
 
 - name: Login as system admin
   shell: "oc login -u system:admin"
-  register: oc_system_admin_login
 
 - name: Get all users
   shell: "oc get user"
@@ -12,8 +11,6 @@
 - name: Create admin user
   shell: "oc create user {{ user_name }}"
   when: "user_name not in all_users.stdout"
-  register: oc_create_user
 
 - name: Give admin user permissions
   shell: "oc adm policy add-cluster-role-to-user edit {{ user_name }}"
-  register: oc_user_policy

--- a/installer/roles/setup-openshift-admin-user/tasks/main.yml
+++ b/installer/roles/setup-openshift-admin-user/tasks/main.yml
@@ -4,13 +4,15 @@
 - name: Login as system admin
   shell: "oc login -u system:admin"
 
-- name: Get all users
-  shell: "oc get user"
-  register: all_users
+- name: Get admin user
+  shell: "oc get user admin"
+  register: admin_user
+  failed_when: false
+  no_log: True
 
 - name: Create admin user
   shell: "oc create user {{ user_name }}"
-  when: "user_name not in all_users.stdout"
+  when: admin_user.rc == 1
 
 - name: Give admin user permissions
   shell: "oc adm policy add-cluster-role-to-user edit {{ user_name }}"


### PR DESCRIPTION
## Motivation
Re-running the ansible service broker setup playbook results in errors (project already exists).  Also re-running after the ASB has been removed or is marked for termination will result in errors because there is left over resources (cluster role bindings, cluster roles and cluster service broker) after deleting the `ansible-service-broker` project or namespace.

## Description
Implement a deprovision task that removes related resources to the ansible service broker.
This task is run only when the `ansible-service-broker` namespace is not found. Not found meaning either A) the ASB was never provisioned (first time provisioning), B)  the ASB was marked for termination (`oc get namespace ansible-service-broker` responds with a `not found`) or C) the ASB has been deleted.
This should improve the idempotency of the playbooks once the changes from this [PR](https://github.com/aerogear/mobile-core/pull/13) are combined and you should be able to re-run the playbook without errors.

## Verification

1. Ensure you have your openshift cluster up and running

2. Checkout this branch locally

3. Delete the admin user `oc delete user admin`

4. Delete the ASB `oc delete namespace ansible-service-broker`

5. Run the playbook `ansible-playbook ./installer/playbook.yml -e "dockerhub_username=$DOCKERHUB_USERNAME" -e "dockerhub_password=$DOCKERHUB_PASSWORD" -e "dockerhub_org=$DOCKERHUB_ORG" --ask-become-pass`

6. There should be no errors logged in the output.

7. Check that the admin user was created `oc get user admin`

8. Check the ASB was created `oc get namespace ansible-service-broker`

9. Re-run the playbook and check that there is no errors and that the admin user and the ASB still exist

