### PR TITLE
Ansible Galaxy Roles Updating

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -227,7 +227,7 @@ function run_installer() {
 
   set -e
   echo "Installing roles to ${SCRIPT_ABSOLUTE_PATH}/roles"
-  ansible-galaxy install -r ./installer/requirements.yml --roles-path="${SCRIPT_ABSOLUTE_PATH}/roles"
+  ansible-galaxy install -r ./installer/requirements.yml --roles-path="${SCRIPT_ABSOLUTE_PATH}/roles" --force
   set +e
 
   if [[ ${oc_version_comparison} -ne ${VER_LT} ]]; then

--- a/installer/requirements.yml
+++ b/installer/requirements.yml
@@ -1,4 +1,5 @@
 - src: andrewrothstein.openshift-origin-client-tools
+  version: v1.0.4
   name: openshift-origin-client-tools
 - src: aidenkeating.install-socat
   name: install-socat


### PR DESCRIPTION
## Motivation
Currently when we install roles in the install script they will not be overwritten with updated roles. Instead the old role will remain.

## Description
This fix specifies the version in the requirements.yml. By just adding the version alone was not enough to update the roles, adding --force tag, forces the update if an update is required, deleting the old role and installing the updated role in its place.

@aidenkeating 


