### PR TITLE
fix: add required permissions to admin user for pushing apbs

### DIFF
--- a/installer/roles/setup-openshift-admin-user/tasks/main.yml
+++ b/installer/roles/setup-openshift-admin-user/tasks/main.yml
@@ -15,4 +15,7 @@
   when: admin_user.rc == 1
 
 - name: Give admin user permissions
-  shell: "oc adm policy add-cluster-role-to-user edit {{ user_name }}"
+  shell: | 
+    oc adm policy add-cluster-role-to-user edit {{ user_name }}
+    oc adm policy add-cluster-role-to-user cluster-admin {{ user_name }}
+    oc adm policy add-cluster-role-to-user access-asb-role {{ user_name }}


### PR DESCRIPTION
At the moment these additional permissions need to be added every time a new cluster created if you intend on working with APBs locally (pushing, bootstrapping, relisting etc.)

It would be nice to get this fixed!

