### PR TITLE
Changing the integration tests to use test.short flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ node("mobile-core-install-slave") {
             retry(3) {
                sleep wait
                wait = wait * 3
-               sh "./integration.test -test.v -goldenFiles=`pwd`/integration -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
+               sh "./integration.test -test.short -test.v -goldenFiles=`pwd`/integration -prefix=test-${sanitizeObjectName(env.BRANCH_NAME)}-build-$BUILD_NUMBER -namespace=`oc project -q` -executable=`pwd`/mobile"
             }
         }
     }


### PR DESCRIPTION
## Motivation

Currently we are only runing -short tests in our mobile-cli PRs. We should be doing the same in mobile-core.