### PR TITLE
Add link of shared keycloak service demo video

### DIFF
--- a/docs/walkthroughs/provision-keycloak-apb.adoc
+++ b/docs/walkthroughs/provision-keycloak-apb.adoc
@@ -4,6 +4,8 @@
 http://www.keycloak.org[Keycloak] is a complete identity and access management solution that provides
 features such as single-sign on, user federation and authorization services.
 
+See https://youtu.be/p8xvBA6UFRY[this video] which demonstrates how to use a shared Keycloak service and how to link another Keycloak service to it.
+
 [[provision-keycloak-service]]
 == Provision
 Choose the type of service you would like to provision:


### PR DESCRIPTION
## Description
Added the link of the video demonstrating how to use a shared keycloak service and how to link another keycloak service to it to the keycloak apb documentation. 

## Progress
- [x] Add link of shared keycloak service demo video to the docs

## Additional Notes
Demo video is produced by the following JIRA - https://issues.jboss.org/browse/AEROGEAR-2171
