### PR TITLE
AEROGEAR-2491 - Update apb local development docs

### DIFF
--- a/docs/walkthroughs/developing-apbs-locally.adoc
+++ b/docs/walkthroughs/developing-apbs-locally.adoc
@@ -25,12 +25,7 @@ This gives 3 distinct users:
 
 == Installing the apb CLI
 
-The `apb` CLI can be installed locally, however we recommend using it wrapped in a Linux container. To create an alias for the dockerized `apb` CLI:
-
-....
-alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools'
-....
-
+Install the apb CLI using one of the options described link:https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#installing-the-apb-tool[here], we recommend you use the link:https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#running-from-a-container[running from a container] method.
 
 == Creating an APB
 
@@ -178,17 +173,15 @@ for your service.
 To build an APB:
 
 ....
-make apb_build
+apb build
 ....
-
-Alternatively, if you have set up the alias described above you can directly use `apb build`.
 
 == Push an APB to a Local Openshift Cluster
 
 Assuming your OpenShift cluster is up and running, you can push the APB image to the local OpenShift Docker Registry with:
 
 ....
-apb push -o
+apb push
 ....
 
 Afterwards your APB is ready to be used from the _Service Catalog_.
@@ -197,7 +190,7 @@ Afterwards your APB is ready to be used from the _Service Catalog_.
 ====
 * If you push an APB and immediately try to provision it, sometimes it fails. Wait about 20 seconds and try again. This is a link:https://bugzilla.redhat.com/show_bug.cgi?id=1501523[known bug in the OpenShift Ansible Broker].
 
-* Using `make build_and_push` executes all phases at once.
+* Using `apb push` executes all phases at once, and automatically does a relist (`apb relist`) on the service catalog.
 ====
 
 == Configure OpenShift Ansible Broker to use Dockerhub Regsitry
@@ -226,21 +219,6 @@ This will allow you to edit the OAB config in your terminal. Under the `registri
 ....
 
 You can also edit the `broker-config` Config Map in the OpenShift web console under the `ansible-service-broker` project. Check the link:https://github.com/openshift/ansible-service-broker/blob/master/docs/config.md[Ansible Service Broker configuration docs] for more examples.
-
-== Push to Dockerhub Account
-Build and push the _APB_ to Dockerhub with the following:
-
-....
-make DOCKERORG="my_org" docker_push
-....
-
-NOTE: Set `DOCKERHOST="<host>"` to use a different regsitry. The default is `docker.io`.
-
-Then force the OpenShift Ansible Broker to relist images from Dockerhub:
-
-....
-apb relist
-....
 
 == Debugging an APB 
 


### PR DESCRIPTION
## Motivation

The local apb development process we are describing seems to be out of date with the official apb development process and documentation. 

## Description

Point the mobile apb developers to the ansible playbook bundle documentation for setup instructions for the apb developer tools. If you install the apb tools locally, or use the upstream containerised installation of the apb tools, local development can be achieved without the need for pushing to an external docker registry.

## Progress

- [x] Finished task
-
## Additional Notes

