### PR TITLE
remove patterns from CRD

### DIFF
--- a/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
+++ b/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
@@ -29,7 +29,3 @@ spec:
               pattern: '(\w-)'
             appIdentifier:
               type: string
-            excludedServices:
-              type: array
-              items:
-                type: string


### PR DESCRIPTION
## Motivation
These patterns are autogenerating a strange required params field that cannot be satisfied. Removing them for now, to unblock other work, until we properly understand how these function.