### PR TITLE
added xamarin client type

### DIFF
--- a/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
+++ b/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
@@ -20,7 +20,7 @@ spec:
           properties:
             clientType:
               type: string
-              pattern: 'cordova|iOS|android'
+              pattern: 'cordova|iOS|android|xamarin'
             apiKey:
               type: string
               pattern: '(\w{8}-\w{4}-\w{4}-\w{4}-\w{11})'


### PR DESCRIPTION
## Motivation

Xamarin client type creation is failing when using minishift.

## Description

Added "xamarin" client type in mobile-client-crd.yaml

