### PR TITLE
AEROGEAR-2602 add dmz url prperty to MAR CRD

### DIFF
--- a/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
+++ b/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
@@ -32,4 +32,5 @@ spec:
               pattern: '([\w-])'
             dmzUrl:
               type: string
+              nullable: true
               pattern: '(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)'

--- a/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
+++ b/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml
@@ -29,3 +29,7 @@ spec:
               pattern: '([\w-])'
             appIdentifier:
               type: string
+              pattern: '([\w-])'
+            dmzUrl:
+              type: string
+              pattern: '(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)'


### PR DESCRIPTION
## JIRA 
https://issues.jboss.org/browse/AEROGEAR-2602

## Verification notes
- `oc delete -f mobile-client-crd.yaml`
- `oc create -f https://raw.githubusercontent.com/witmicko/mobile-core/56c53c5a1e0eef7f9b5b60ffcfabd5bdf587309c/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml`
- `minishift openshift restart`
- Add mobile client to your project
- Resources > other > mobile client > actions > edit YAML
- add `  dmzUrl: invalidUrl` at the bottom of mobile crd > should get a validation error on save
- try different urls:
`www.hello.com.ok`
`http://www.hello.com.ok`
`http://www.hello.com.ok/ersdfs`
`http://www.hello.com.ok/ersdfs?dfd=dfgd@s=1`
`http://www.hello.com:81/index.html`