### PR TITLE
add information on provision issue when apb is set to be bindable

### DIFF
--- a/docs/walkthroughs/developing-apbs-locally.adoc
+++ b/docs/walkthroughs/developing-apbs-locally.adoc
@@ -179,6 +179,9 @@ An example can be seen link:https://github.com/aerogearcatalog/keycloak-apb/blob
 You can also link:https://github.com/aerogearcatalog/metrics-apb#how-to-add-a-new-dashboard-while-provisioning-a-service[include a  custom Grafana dashboard] 
 for your service.
 
+=== Issues with Bindable APBs
+There is currently an link:https://github.com/openshift/ansible-service-broker/issues/847[issue] when setting an APB to be bindable without encoding binding fields for ansible service broker during provision. Ensure the provision successfully completes by encoding binding fields during provision when your APB is set to be bindable.
+
 == Building an APB
 
 To build an APB:


### PR DESCRIPTION
## Description
There is an issue with setting an APB to be bindable without encoding any binding fields during provision. The provision tasks gives no errors and the task completes successfully but the provision still fails. This needs to be added to the documentation for developing apbs for awareness until this issue has been resolved.

## Progress
- [x] Add information of the asb issue during provision for bindable apbs

## Additional Notes
https://github.com/openshift/ansible-service-broker/issues/847
