### PR TITLE
Removing integration tests from the end of PR-check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,10 @@ String sanitizeObjectName(String s) {
         .replaceAll("^-+", "")
 }
 
+stage('Trust') {
+    enforceTrustedApproval('aerogear')
+}
+
 node("mobile-core-install-slave") {
     step([$class: 'WsCleanup'])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node("mobile-core-install-slave") {
     
 
     def labels = getPullRequestLabels {}  
-    if(currentBuild.result == 'FAILURE' && labels.contain("leave slave on failure")) {
+    if(currentBuild.result == 'FAILURE' && labels.contains("leave slave on failure")) {
         stage ("Failure Investigation") {
             timeout(time: 12, unit: 'HOURS') {
                     input "Confirm to end the job and dispose of the slave node."


### PR DESCRIPTION
As stated in https://issues.jboss.org/browse/RHMAP-20431
Running of the ansible stays.
The slave will stay around only if "leave slave on failure is applied".