### PR TITLE
Cicd doc fix

### DIFF
--- a/docs/walkthroughs/provision-mobile-ci-cd.adoc
+++ b/docs/walkthroughs/provision-mobile-ci-cd.adoc
@@ -81,3 +81,5 @@ country=IRL
 storepass=android
 keypass=android
 ```
+
+Please refer to the official documentation for in-depth information about android keystore configuration: https://developer.android.com/studio/publish/app-signing#signing-manually

--- a/docs/walkthroughs/provision-mobile-ci-cd.adoc
+++ b/docs/walkthroughs/provision-mobile-ci-cd.adoc
@@ -11,8 +11,6 @@ The Mobile CI/CD service depends on the following container images:
 * aerogear/digger-android-slave-image
 * aerogear/digger-android-sdk-image
 
-Aerogear Digger documentation can be found at: https://aerogear.org/digger.
-
 == Provisioning
 
 Select the "Mobile" tab in openshift service catalog and click on "Mobile CI|CD":


### PR DESCRIPTION
- Removes aerogear digger link from overview section
- Adds a link to the official android doc