### PR TITLE
add oc cluster status to end of output.

### DIFF
--- a/installer/playbook.yml
+++ b/installer/playbook.yml
@@ -26,5 +26,8 @@
   - role: patch-origin-web-console
     tags: [setup-mcp, local, local-dev]
 
+  - role: output-oc-cluster-status
+    tags: [local, local-dev]
+
   vars_files:
   - "vars/mobile-control-panel.yml"

--- a/installer/roles/output-oc-cluster-status/tasks/main.yml
+++ b/installer/roles/output-oc-cluster-status/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: get status
+  command: oc cluster status
+  register: cluster_status
+
+- debug: msg="{{ cluster_status.stdout_lines }}"


### PR DESCRIPTION
## Motivation
add oc cluster status to end of output.

## Description
add oc cluster status to end of output.

```
16:25 $ ./installer/install.sh 
  __  __  ____ ____
 |  \/  |/ ___|  _ \
 | |\/| | |   | |_) |
 | |  | | |___|  __/
 |_|  |_|\____|_|

.... <snip> .....
TASK [output-oc-cluster-status : debug] ******************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "Web console URL: https://192.168.37.1:8443/console/", 
        "", 
        "Config is at host directory /var/lib/origin/openshift.local.config", 
        "Volumes are at host directory /var/lib/origin/openshift.local.volumes", 
        "Persistent volumes are at host directory /var/lib/origin/openshift.local.pv", 
        "Data is at host directory /home/pbrookes/Projects/src/github.com/aerogear/mobile-core/ui/openshift-data"
    ]
}

PLAY RECAP ***********************************************************************************************************************************************************************************
localhost                  : ok=44   changed=17   unreachable=0    failed=0   

✔ ~/Projects/src/github.com/aerogear/mobile-core [master|✚ 1…20842] 
```