### PR TITLE
removes the call to the banner function

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -235,7 +235,6 @@ function run_installer() {
   fi
 }
 
-banner
 check_docker
 check_python
 check_ansible


### PR DESCRIPTION
## Motivation
the installer immediately pauses when run. This was due to the unneeded call for the banner. 
