### PR TITLE
set image pull policy to Always for origin-console

### DIFF
--- a/installer/roles/patch-origin-web-console/tasks/main.yml
+++ b/installer/roles/patch-origin-web-console/tasks/main.yml
@@ -13,11 +13,8 @@
 
 - name: Deploy origin web console image {{ origin_web_console_image }}
   block:
-    - name: Set imagePullPolicy to Always
-      shell: "oc patch deployment webconsole -n openshift-web-console -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"webconsole\", \"imagePullPolicy\": \"Always\"}]}}}}'"
-
     - name: "Patch webconsole deployment"
-      shell: "oc patch deployment webconsole -n openshift-web-console -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"webconsole\", \"image\": \"{{origin_web_console_image}}\"}]}}}}'"
+      shell: "oc patch deployment webconsole -n openshift-web-console -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"webconsole\", \"image\": \"{{origin_web_console_image}}\", \"imagePullPolicy\": \"Always\"}]}}}}'"
 
     - name: "Wait for the pod to be ready"
       shell: "oc get pods -n openshift-web-console | grep 'webconsole' | grep -v 'deploy' | grep 'Running'"

--- a/installer/roles/patch-origin-web-console/tasks/main.yml
+++ b/installer/roles/patch-origin-web-console/tasks/main.yml
@@ -13,6 +13,8 @@
 
 - name: Deploy origin web console image {{ origin_web_console_image }}
   block:
+    - name: Set imagePullPolicy to Always
+      shell: "oc patch deployment webconsole -n openshift-web-console -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"webconsole\", \"imagePullPolicy\": \"Always\"}]}}}}'"
 
     - name: "Patch webconsole deployment"
       shell: "oc patch deployment webconsole -n openshift-web-console -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"webconsole\", \"image\": \"{{origin_web_console_image}}\"}]}}}}'"


### PR DESCRIPTION
## Motivation
origin-web-console doesn't get updated when a stale image is present.

![image](https://user-images.githubusercontent.com/3279642/41923224-d11262a2-795e-11e8-96a3-87a4a257f6d0.png)


JIRA: https://issues.jboss.org/browse/AEROGEAR-3397

## Verification steps:
1. checkout these changes
2. `make clean && ./installer/install.sh`
3.  login as admin
4. ensure that origin-web-console config yaml has imagePullPolicy set to Always