### PR TITLE
Add a new role to provision mobile core on rhpds

### DIFF
--- a/installer/rhpds-playbook.yml
+++ b/installer/rhpds-playbook.yml
@@ -3,6 +3,8 @@
 - name: Setup OpenShift cluster with the Mobile Core
   hosts: localhost
   roles:
+  - role: ansible-service-broker-setup
+    tags: update-broker 
   - role: provision-mobile-catalog
     tags: provision
 

--- a/installer/rhpds-playbook.yml
+++ b/installer/rhpds-playbook.yml
@@ -3,8 +3,6 @@
 - name: Setup OpenShift cluster with the Mobile Core
   hosts: localhost
   roles:
-  - role: ansible-service-broker-setup
-    tags: update-broker 
   - role: provision-mobile-catalog
     tags: provision
 

--- a/installer/rhpds-playbook.yml
+++ b/installer/rhpds-playbook.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Setup OpenShift cluster with the Mobile Core
+  hosts: localhost
+  roles:
+  - role: provision-mobile-catalog
+    tags: provision
+
+  vars_files:
+  - "vars/mobile-control-panel.yml"

--- a/installer/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/installer/roles/ansible-service-broker-setup/defaults/main.yml
@@ -8,3 +8,4 @@ skip_apb:
 apb_sync: false
 ansible_service_broker_namespace: ansible-service-broker
 image_pull_policy: Always
+check_oc_cluster_status: true

--- a/installer/roles/ansible-service-broker-setup/tasks/main.yml
+++ b/installer/roles/ansible-service-broker-setup/tasks/main.yml
@@ -80,14 +80,17 @@
   until: oc_cluster_status.rc == 0
   poll: 5
   retries: 30
+  when: check_oc_cluster_status
 
 - name: Get oc cluster status
   shell: oc cluster status
   register: oc_cluster_status
   changed_when: false
+  when: check_oc_cluster_status
 
 - debug:
     msg: "{{ oc_cluster_status.stdout_lines }}"
+  when: check_oc_cluster_status
 
 - block:
   - debug:
@@ -97,4 +100,4 @@
       - If it's not, run export PATH={{ oc_install_parent_dir }}:$PATH, to persist this PATH do
       - echo 'export PATH={{ oc_install_parent_dir }}:$PATH' >> ~/.bash_profile
   when:
-  - oc_install_parent_dir is defined
+  - check_oc_cluster_status and oc_install_parent_dir is defined

--- a/installer/roles/patch-origin-web-console/tasks/main.yml
+++ b/installer/roles/patch-origin-web-console/tasks/main.yml
@@ -1,8 +1,15 @@
 ---
 # tasks file for patch-origin-web-console
+- name: Get current user
+  shell: "oc whoami"
+  register: "oc_whoami_output"
+
+- set_fact:
+    current_user: "{{oc_whoami_output.stdout}}"
 
 - name: Login as system admin
   shell: "oc login -u system:admin"
+  when: current_user != "system:admin"
 
 - name: Get current deployed origin webconsole image
   shell: "oc get deployment webconsole -n openshift-web-console -o=jsonpath='{.spec.template.spec.containers[?(@.name==\"webconsole\")].image}'"

--- a/installer/roles/provision-mobile-catalog/defaults/main.yml
+++ b/installer/roles/provision-mobile-catalog/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ansible_service_broker_namespace: openshift-ansible-service-broker

--- a/installer/roles/provision-mobile-catalog/files/broker-config.yaml
+++ b/installer/roles/provision-mobile-catalog/files/broker-config.yaml
@@ -1,0 +1,64 @@
+registry:
+  - type: rhcc
+    name: rh
+    url: https://registry.access.redhat.com
+    org:
+    tag: v3.9.27
+    white_list: ['.*-apb$']
+    auth_type: ""
+    auth_name: ""
+
+  - type: dockerhub
+    name: ag
+    url: https://registry.hub.docker.com
+    org: aerogearcatalog
+    tag: 1.0.0
+    white_list:
+      - '.*-apb$'
+
+  - type: local_openshift
+    name: localregistry
+    namespaces: ['openshift']
+    white_list: ['.*-apb$']
+
+  - name: openshiftapb
+    type: dockerhub
+    org: openshiftapb
+    tag: ocp-3.9
+    white_list:
+      - ".*-apb$"
+
+dao:
+  etcd_host: asb-etcd.openshift-ansible-service-broker.svc
+  etcd_port: 2379
+  etcd_ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+  etcd_client_cert: /var/run/asb-etcd-auth/client.crt
+  etcd_client_key: /var/run/asb-etcd-auth/client.key
+
+log:
+  stdout: true
+  level: info
+  color: true
+
+openshift:
+  host: ""
+  ca_file: ""
+  bearer_token_file: ""
+  sandbox_role: admin
+  image_pull_policy: IfNotPresent
+  keep_namespace: false
+  keep_namespace_on_error: true
+
+broker:
+  dev_broker: false
+  bootstrap_on_startup: true
+  refresh_interval: 600s
+  launch_apb_on_bind: true
+  output_request: false
+  recovery: true
+  ssl_cert_key: /etc/tls/private/tls.key
+  ssl_cert: /etc/tls/private/tls.crt
+  auto_escalate: True
+  auth:
+    - type: basic
+      enabled: false

--- a/installer/roles/provision-mobile-catalog/tasks/main.yml
+++ b/installer/roles/provision-mobile-catalog/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+
+# tasks for provision mobile catalog on an existing openshift cluster
+# NOTE: Ansible Service Broker should be already provisoned in this cluster
+- name: Get current user
+  shell: "oc whoami"
+  register: "oc_whoami_output"
+
+- set_fact:
+    current_user: "{{oc_whoami_output.stdout}}"
+
+- name: Login as system admin
+  shell: "oc login -u system:admin"
+  when: current_user != "system:admin"
+
+- import_role:
+    name: create-mobile-client-crd
+
+- name: Copy broker config file
+  copy:
+      src: ../files/broker-config.yaml
+      dest: /tmp/broker-config.yaml
+
+# TODO: ideally we want to parse the broker config to add the new registry and update the config, but for now we keep it simple
+- name: Update ansible service broker config
+  shell: |
+    oc delete configmap broker-config -n {{ansible_service_broker_namespace}}
+    oc create configmap broker-config --from-file=broker-config=/tmp/broker-config.yaml -n {{ansible_service_broker_namespace}}
+
+- name: Rollout ansible service broker
+  shell: oc rollout latest asb -n  {{ansible_service_broker_namespace}}
+
+- name: Refresh Catalog
+  shell: |
+    oc get clusterservicebroker ansible-service-broker -o=json > /tmp/broker.json
+    oc delete clusterservicebroker ansible-service-broker
+    sleep 10
+    oc create -f /tmp/broker.json
+
+- import_role:
+    name: patch-origin-web-console
+  
+
+  


### PR DESCRIPTION
## Motivation

This will allow us to provision mobile core on the OpenShift instances that are created by RHPDS.

To verify:

1. Provision a openshift instance from RHPDS (can use this one: `ssh -i ocp-workshop.pem ec2-user@bastion.mobiletest1.openshiftworkshop.com`, I will email you the private key)
2. SSH into the workstation, and run the following command:
    ```
    sudo bash
    git clone https://github.com/wei-lee/mobile-core.git
    git checkout aerogear-mobile-role
    ansible-playbook installer/rhpds-playbook.yml
    ```
   When it is finished, the mobile tab should be available in the catalog

@johnfriz @maleck13 can you take a look?
