### PR TITLE
Revert dependency fix

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -108,17 +108,17 @@ function check_ansible() {
 
   command -v ansible &>/dev/null
   ansible_exists=${?}; if [[ ${ansible_exists} -ne 0 ]]; then
-    does_not_exist_msg "Ansible" "pip install ansible>=2.3"
+    does_not_exist_msg "Ansible" "pip install ansible>=2.6"
     exit 1
   fi
   check_passed_msg "Ansible"
 
   readonly ansible_version=$(ansible --version | sed -n '1p' | cut -d " " -f2)
 
-  check_version_msg "Ansible" ">= 2.3"
-  compare_version ${ansible_version} 2.3
+  check_version_msg "Ansible" ">= 2.6"
+  compare_version ${ansible_version} 2.6
   ansible_version_comparison=${?}; if [[ ${ansible_version_comparison} -eq ${VER_LT} ]]; then
-    echo -e "${RED}Ansible version is < 2.3. Install ansible>=2.3 using pip install ansible>=2.3${RESET}"
+    echo -e "${RED}Ansible version is < 2.6. Install ansible>=2.6 using pip install ansible>=2.6${RESET}"
     exit 1
   fi
   check_passed_msg "Ansible"

--- a/installer/requirements.yml
+++ b/installer/requirements.yml
@@ -1,6 +1,6 @@
-- src: aerogear.ansible_openshift_origin_client_tools
+- src: andrewrothstein.openshift-origin-client-tools
+  version: v1.0.7
   name: openshift-origin-client-tools
-  version: v1.0.3
 - src: aerogear.install_socat
   name: install-socat
   version: v1.0.0


### PR DESCRIPTION
Was getting this error still (master & 1.0.0 tag of mobile-core):

```
 [WARNING]: - andrewrothstein.alpine_glibc_shim was NOT installed successfully: - sorry, andrewrothstein.alpine_glibc_shim was not
found on https://galaxy.ansible.com.
```

even after the changes in https://github.com/aerogear/mobile-core/pull/119

From reading the latest updates on: https://github.com/ansible/galaxy/issues/775, it looks as though ansible galaxy have fixed this.

This change:

- reverts https://github.com/aerogear/mobile-core/pull/119 (should no longer be needed)
- Update ansible version check to something more recent (2.6)