### PR TITLE
fix(installer): Message when python is not installed

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## Unreleased
+  * [installer] - Fix message when python is not installed  
+
+## Released
 
 0.0.6 / 2017-11-02
 ==================

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -58,7 +58,7 @@ function check_passed_msg() {
 }
 
 function check_docker() {
-  check_exists_msg "Docker" 
+  check_exists_msg "Docker"
   command -v docker &>/dev/null
   docker_exists=${?}; if [[ ${docker_exists} -ne 0 ]]; then
     does_not_exist_msg "Docker" "https://www.docker.com/get-docker"
@@ -88,7 +88,7 @@ function check_python() {
 
   command -v python &>/dev/null
   python_exists=${?}; if [[ ${python_exists} -ne 0 ]]; then
-    does_not_exist_msg "Python" "pip install ansible>=2.3"
+    does_not_exist_msg "Python" "https://docs.python.org/3/using/unix.html#getting-and-installing-the-latest-version-of-python"
   fi
   check_passed_msg "Python"
 


### PR DESCRIPTION
## Motivation
Issue: https://github.com/aerogear/mobile-core/issues/137

## Description
Just add a link of python doc since to install python is required to follow a procedure according to SO used. 

## Progress

- [x] Finished task
- [] TODO

## Additional Notes
Following local test to check the message/change. 

<img width="861" alt="screen shot 2018-07-12 at 17 32 49" src="https://user-images.githubusercontent.com/7708031/42646810-e6cff486-85f9-11e8-81cf-29c39b939309.png">


