### PR TITLE
fix(installer): Add 'oc cluster up' validation

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -30,6 +30,40 @@ readonly MIN_OCP_CLIENT_TOOL=3.9
 # 0 - =
 # 1 - >
 # 2 - <
+
+function spinner() {
+  case $1 in
+    start)
+      let column=$(tput cols)-${#2}-8
+      echo -ne ${2}
+      printf "%${column}s"
+      local i sp n
+      sp='/-\|'
+      n=${#sp}
+      while sleep 0.1; do
+        printf "%s\b" "${sp:i++%n:1}"
+      done
+      ;;
+    stop)
+      if [[ -z ${3} ]]; then
+        exit 1
+      fi
+      echo -e "\n"
+      kill $3 > /dev/null 2>&1
+    esac
+}
+
+function spinnerStart {
+  spinner "start" "${1}" &
+  pid=$!
+  disown
+}
+
+function spinnerStop {
+  spinner "stop" $1 $pid
+  unset pid
+}
+
 function compare_version () {
   if [[ $1 == $2 ]]; then
     return 0
@@ -60,6 +94,10 @@ function does_not_exist_msg() {
 
 function check_exists_msg() {
   echo -e "\nChecking ${1} exists"
+}
+
+function check_msg() {
+  echo -e "\nChecking ${1}"
 }
 
 function check_version_msg() {
@@ -208,6 +246,25 @@ function read_wildcard_dns_host() {
   done
 }
 
+# To avoid known issues when the cluster need to started
+function check_oc_cluster_up() {
+  check_msg "Openshift cluster"
+  spinnerStart 'Running oc cluster up ...'
+  command oc cluster up &>/dev/null
+  cluster_running=${?};
+  spinnerStop $?
+  if [[ ${cluster_running} -ne 0 ]]; then
+    (command oc cluster up 2>&1 | grep 'Error: OpenShift is already running') &>/dev/null
+    if [[ ${?} -ne 0 ]];  then # if it is already running the check passed
+      command oc cluster up # to show output
+      echo -e "${RED}Error to run 'oc cluster up'. ${RESET}"
+      echo -e "${RED}See https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#getting-started. ${RESET}"
+      exit 1
+    fi
+  fi
+  check_passed_msg "Openshift cluster"
+}
+
 # To read and check docker credentials
 function read_docker_hub_credentials() {
   echo -e "\nThe Mobile installer requires valid DockerHub credentials
@@ -315,4 +372,5 @@ check_docker
 check_python
 check_ansible
 check_oc
+check_oc_cluster_up
 run_installer


### PR DESCRIPTION
## Motivation
Issue: https://github.com/aerogear/mobile-core/issues/132

## Description
* Run 'oc cluster up' before ansible tasks in order to check it. 
* Add spinner in the script in order to inform that the action is in progress
* If  'oc cluster up' has an error show the error and suggest the link of the docs to solve it
* If the error is because of it already is up then the checked need to pass to

<img width="997" alt="screen shot 2018-07-12 at 23 05 03" src="https://user-images.githubusercontent.com/7708031/42662052-0a3fab86-8628-11e8-8588-433e9ab107c5.png">

## Progress

- [X] Finished task

## Additional Notes

### Steps to check it. 
* Go to the local docker >> preferences and remove the o --insecure-registry.

<img width="452" alt="screen shot 2018-07-12 at 18 38 31" src="https://user-images.githubusercontent.com/7708031/42658901-976b7f4e-861e-11e8-8758-23ec4b716816.png">

* Then,  the following error which is expected if the oc cluster up command is executed. 

<img width="774" alt="screen shot 2018-07-13 at 08 58 19" src="https://user-images.githubusercontent.com/7708031/42679849-30b7c340-867b-11e8-9957-4e4629e6d486.png">

* Now executed the script `./installer/install.sh ` the following error message is expected. 

## Test performed locally
* When the cluster has an error ( --insecure-registry not setup )
* When the cluster is already up
* When the clsuter is down and all is properly setup 

