### PR TITLE
fix(installer): Installer output does not make clear which password is required and ask more than once for this information

### DIFF
--- a/docs/walkthroughs/local-setup.adoc
+++ b/docs/walkthroughs/local-setup.adoc
@@ -11,7 +11,7 @@ This walkthrough sets up a locally running OpenShift cluster for:
 == Requirements
 
 === Hardware Requirements
-* Please make sure that you have at least *64GiB* of free space on your filesystem 
+* Please make sure that you have at least *64GiB* of free space on your filesystem
 * for smooth run have 16GiB of RAM
 
 [[tooling-requirements]]
@@ -80,7 +80,7 @@ To run the ansible installer directly and specify any property values:
 ----
 export DOCKERHUB_USERNAME=<my_dockerhub_username>
 export DOCKERHUB_PASSWORD=<my_dockerhub_password>
-ansible-playbook ./installer/playbook.yml -e "dockerhub_username=$DOCKERHUB_USERNAME" -e "dockerhub_password=$DOCKERHUB_PASSWORD" --ask-become-pass
+ansible-playbook ./installer/playbook.yml -e "dockerhub_username=$DOCKERHUB_USERNAME" -e "dockerhub_password=$DOCKERHUB_PASSWORD"
 ----
 
 Alternatively, to run a script that prompts for property values:

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -328,7 +328,8 @@ function read_cluster_ip() {
 
 # To execute ansible task
 function run_ansible_tasks() {
-  echo "Performing clean and running the installer. You will be asked for your password."
+  echo -e "Performing clean and running the installer ..."
+  echo -e "May you will be asked for your System Admin Password(root/sudo)."
 
   cd ${SCRIPT_ABSOLUTE_PATH}
   cd .. && make clean &>/dev/null

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -335,13 +335,13 @@ function run_ansible_tasks() {
   cd .. && make clean &>/dev/null
 
   set -e
-  echo "Installing roles from ${SCRIPT_ABSOLUTE_PATH}/roles"
+  echo "Installing roles to ${SCRIPT_ABSOLUTE_PATH}/roles"
   ansible-galaxy install -r ./installer/requirements.yml --roles-path="${SCRIPT_ABSOLUTE_PATH}/roles" --force
   set +e
 
   if [[ ${oc_version_comparison} -ne ${VER_LT} ]]; then
     echo "Skipping OpenShift client tools installation..."
-    ansible-playbook installer/playbook.yml --ask-become-pass --skip-tags "install-oc" \
+    ansible-playbook installer/playbook.yml --skip-tags "install-oc" \
     -e "dockerhub_username=${dockerhub_username}" \
     -e "dockerhub_password=${dockerhub_password}" \
     -e "dockerhub_tag=${dockerhub_tag}" \
@@ -349,7 +349,7 @@ function run_ansible_tasks() {
     -e "cluster_public_ip=${cluster_ip}" \
     -e "wildcard_dns_host=${wildcard_dns_host}"
   else
-    ansible-playbook installer/playbook.yml --ask-become-pass \
+    ansible-playbook installer/playbook.yml \
     -e "dockerhub_username=${dockerhub_username}" \
     -e "dockerhub_password=${dockerhub_password}" \
     -e "dockerhub_tag=${dockerhub_tag}" \


### PR DESCRIPTION
## Motivation
Issue: https://github.com/aerogear/mobile-core/issues/136
* Installer output does not make clear which password is required
* The root pwd is requested more than once 

## Description
* Remove the param `--ask-become-pass` in ansible task and instead of it executed the tasks as root, since the pwd was already asked in the before action.
* Change the wording/message in order to make clear that is required the sudo/root pwd. 
Following its result. 
```
Performing clean and running the installer ...
You will be asked for your System Admin Password(root/sudo).
Password:

```

## Progress

- [X] Finished task
- [] TODO

## Additional Notes
<img width="798" alt="screen shot 2018-07-15 at 15 53 27" src="https://user-images.githubusercontent.com/7708031/42735166-4f3a87da-8847-11e8-9738-a83d506be22e.png">


Following the FULL local test. 

````
cmacedo@camilas-MBP ~/mobile-core (ISSUE_136) $ ./installer/install.sh 

Checking Docker exists
✓ Docker check passed.
Checking Docker is running
✓ Docker check passed.
Checking Docker version. Should be using Stable channel
✓ Docker check passed.

Checking Python exists
✓ Python check passed.
Checking Python version. Should be >= 2.7
✓ Python check passed.

Checking Ansible exists
✓ Ansible check passed.
Checking Ansible version. Should be >= 2.6
✓ Ansible check passed.

Checking OpenShift client tools exists
✓ OpenShift Client Tools check passed.
Checking OpenShift client tools version. Should be >= 3.9
✓ OpenShift Client Tools check passed.

The Mobile installer requires valid DockerHub credentials
  to communicate with the DockerHub API. If you enter invalid credentials or then
  Mobile Services will not be available in the Service Catalog.

DockerHub Username (Defaults to DOCKERHUB_USERNAME env var): cmacedo
DockerHub Password (Defaults to DOCKERHUB_PASSWORD env var): 
Checking DockerHub credentials are valid...

✓ Docker Credentials check passed.
DockerHub Tag (Defaults to latest): 
DockerHub Organisation (Defaults to aerogearcatalog): 
Cluster IP (Defaults to 192.168.1.9): 
Wildcard DNS Host (Defaults to nip.io): 
Your Wildcard DNS Host is: nip.io.
Performing clean and running the installer ...
May you will be asked for your System Admin Password(root/sudo).
Password:
Installing roles to /Users/cmacedo/mobile-core/installer/roles
- changing role openshift-origin-client-tools from v1.0.7 to v1.0.7
- downloading role 'openshift-origin-client-tools', owned by andrewrothstein
- downloading role from https://github.com/andrewrothstein/ansible-openshift-origin-client-tools/archive/v1.0.7.tar.gz
- extracting openshift-origin-client-tools to /Users/cmacedo/mobile-core/installer/roles/openshift-origin-client-tools
- openshift-origin-client-tools (v1.0.7) was installed successfully
- dependency andrewrothstein.unarchive-deps is already installed, skipping.
- dependency andrewrothstein.alpine-glibc-shim is already installed, skipping.
- changing role install-socat from v1.0.0 to v1.0.0
- downloading role 'install_socat', owned by aerogear
- downloading role from https://github.com/aerogear/install-socat/archive/v1.0.0.tar.gz
- extracting install-socat to /Users/cmacedo/mobile-core/installer/roles/install-socat
- install-socat (v1.0.0) was installed successfully
Skipping OpenShift client tools installation...
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

 [WARNING]: Found variable using reserved name: roles


PLAY [Setup OpenShift cluster with the Mobile Core and Service Brokers] ******************************************

TASK [Gathering Facts] *******************************************************************************************
ok: [localhost]

TASK [install-socat : Check socat exists] ************************************************************************
ok: [localhost]

TASK [install-socat : Create download directory] *****************************************************************
skipping: [localhost]

TASK [install-socat : Retrieve socat tarball] ********************************************************************
skipping: [localhost]

TASK [install-socat : Unarchive socat tarball] *******************************************************************
skipping: [localhost]

TASK [install-socat : Configure] *********************************************************************************
skipping: [localhost]

TASK [install-socat : Make] **************************************************************************************
skipping: [localhost]

TASK [install-socat : Move to install directory] *****************************************************************
skipping: [localhost]

TASK [install-socat : file] **************************************************************************************
skipping: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : Obtain status of oc cluster] ***************************************************************
ok: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
skipping: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : Obtain host config directory with allowed format] ******************************************
changed: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : debug] *************************************************************************************
ok: [localhost] => {
    "msg": "Host config dir is /Users/cmacedo/mobile-core/ui"
}

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
skipping: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : set_fact] **********************************************************************************
ok: [localhost]

TASK [oc-cluster-up : debug] *************************************************************************************
ok: [localhost] => {
    "msg": "Executing oc cluster up command - oc cluster up --service-catalog=true --host-data-dir=/Users/cmacedo/mobile-core/ui/openshift-data --routing-suffix=192.168.1.9.nip.io --public-hostname=192.168.1.9 --version=v3.9.0 --image=openshift/origin"
}

TASK [oc-cluster-up : Cluster up] ********************************************************************************
ok: [localhost]

TASK [template-service-broker-setup : Login to OpenShift] ********************************************************
ok: [localhost]

TASK [template-service-broker-setup : Add cluster roles to group] ************************************************
ok: [localhost]

TASK [setup-openshift-admin-user : Login as system admin] ********************************************************
changed: [localhost]

TASK [setup-openshift-admin-user : Get admin user] ***************************************************************
changed: [localhost]

TASK [setup-openshift-admin-user : Create admin user] ************************************************************
changed: [localhost]

TASK [setup-openshift-admin-user : Give admin user permissions] **************************************************
changed: [localhost]

TASK [create-mobile-client-crd : Check for mobileClient CRD] *****************************************************
changed: [localhost]

TASK [create-mobile-client-crd : Copy CRD definition to tmp file] ************************************************
ok: [localhost]

TASK [create-mobile-client-crd : Create mobileClient CRD] ********************************************************
changed: [localhost]

TASK [create-mobile-client-crd : Create mobile-admin clusterrole] ************************************************
changed: [localhost]

TASK [create-mobile-client-crd : Add mobileclient-admin role to authenticated users] *****************************
changed: [localhost]

TASK [ansible-service-broker-setup : List all public APB's in aerogearcatalog docker org] ************************
skipping: [localhost]

TASK [ansible-service-broker-setup : Copy APB's from aerogearcatalog docker org to aerogearcatalog] **************
skipping: [localhost]

TASK [ansible-service-broker-setup : Check If OpenShift Ansible Broker Is Installed] *****************************
changed: [localhost]

TASK [ansible-service-broker-setup : Ensure OpenShift Ansible Broker Is Deprovisioned] ***************************
changed: [localhost]

TASK [ansible-service-broker-setup : Ensure OpenShift Ansible Broker (OAB) install script is on host] ************
ok: [localhost]

TASK [ansible-service-broker-setup : Make OpenShift Ansible Broker (OAB) install script executable] **************
ok: [localhost]

TASK [ansible-service-broker-setup : Execute OpenShift Ansible Broker (OAB) provision script] ********************
changed: [localhost]

TASK [ansible-service-broker-setup : Ensure oc cluster is up] ****************************************************
FAILED - RETRYING: Ensure oc cluster is up (30 retries left).
FAILED - RETRYING: Ensure oc cluster is up (29 retries left).
FAILED - RETRYING: Ensure oc cluster is up (28 retries left).
FAILED - RETRYING: Ensure oc cluster is up (27 retries left).
ok: [localhost]

TASK [ansible-service-broker-setup : Get oc cluster status] ******************************************************
ok: [localhost]

TASK [ansible-service-broker-setup : debug] **********************************************************************
ok: [localhost] => {
    "msg": [
        "Web console URL: https://192.168.1.9:8443/console/", 
        "", 
        "Config is at host directory /var/lib/origin/openshift.local.config", 
        "Volumes are at host directory /var/lib/origin/openshift.local.volumes", 
        "Persistent volumes are at host directory /var/lib/origin/openshift.local.pv", 
        "Data is at host directory /Users/cmacedo/mobile-core/ui/openshift-data"
    ]
}

TASK [ansible-service-broker-setup : debug] **********************************************************************
ok: [localhost] => {
    "msg": [
        "/usr/local/bin/oc was used to create your cluster.", 
        "Ensure that /usr/local/bin is on your PATH.", 
        "If it's not, run export PATH=/usr/local/bin:$PATH, to persist this PATH do", 
        "echo 'export PATH=/usr/local/bin:$PATH' >> ~/.bash_profile"
    ]
}

TASK [patch-origin-web-console : Login as system admin] **********************************************************
changed: [localhost]

TASK [patch-origin-web-console : Get current deployed origin webconsole image] ***********************************
changed: [localhost]

TASK [patch-origin-web-console : set_fact] ***********************************************************************
ok: [localhost]

TASK [patch-origin-web-console : Patch webconsole deployment] ****************************************************
changed: [localhost]

TASK [patch-origin-web-console : Wait for the pod to be ready] ***************************************************
FAILED - RETRYING: Wait for the pod to be ready (60 retries left).
FAILED - RETRYING: Wait for the pod to be ready (59 retries left).
FAILED - RETRYING: Wait for the pod to be ready (58 retries left).
changed: [localhost]

TASK [output-oc-cluster-status : get status] *********************************************************************
changed: [localhost]

TASK [output-oc-cluster-status : debug] **************************************************************************
ok: [localhost] => {
    "msg": [
        "Web console URL: https://192.168.1.9:8443/console/", 
        "", 
        "Config is at host directory /var/lib/origin/openshift.local.config", 
        "Volumes are at host directory /var/lib/origin/openshift.local.volumes", 
        "Persistent volumes are at host directory /var/lib/origin/openshift.local.pv", 
        "Data is at host directory /Users/cmacedo/mobile-core/ui/openshift-data"
    ]
}

TASK [Link to documentation for using cluster certs on client] ***************************************************
ok: [localhost] => {
    "msg": "For information on how to enable TLS communication on your device to this cluster see https://docs.aerogear.org/aerogear/latest/getting-started.html#using-self-signed-certificates-in-mobile-apps\"\n"
}

PLAY RECAP *******************************************************************************************************
localhost                  : ok=43   changed=17   unreachable=0    failed=0   

cmacedo@camilas-MBP ~/mobile-core (ISSUE_136) $ 
````