### PR TITLE
fix(installer): Default values standard and making clear Docker input values

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -269,7 +269,7 @@ function read_wildcard_dns_host() {
       read_with_default_values "Wildcard DNS Host" ${DEFAULT_WILDCARD_DNS_HOST} wildcard_dns_host
       wildcard_dns_host=${wildcard_dns_host:-${DEFAULT_WILDCARD_DNS_HOST}}
       if [[ $wildcard_dns_host == *.* ]]; then
-        echo "Your Wildcard DNS Host is: ${wildcard_dns_host}."
+        check_passed_msg "Wildcard DNS Host"
         break
       else
         echo -e  "${RED} The value ${wildcard_dns_host} is an invalid Wildcard DNS Host. ${RESET}"


### PR DESCRIPTION
## Motivation
Issue: https://github.com/aerogear/mobile-core/issues/134

## Description
* Apply a similar standard that we we have for our fh tools regards the default values
* Apply hidden password
* Show the default values which will be added. 
 
## Progress

- [x] Finished task
- [] TODO

## Additional Notes

Following local tests. 

### Without  env vars exported.
<img width="569" alt="screen shot 2018-07-14 at 16 43 06" src="https://user-images.githubusercontent.com/7708031/42725979-090beaa0-8785-11e8-8d58-9dbb0dfb041a.png">

#### * Checking validations
<img width="570" alt="screen shot 2018-07-14 at 16 42 40" src="https://user-images.githubusercontent.com/7708031/42725984-137536ae-8785-11e8-944e-44d64464437a.png">

### With env var exported. 
`$export DOCKERHUB_USERNAME=<value>`
`$export DOCKERHUB_PASSWORD=<value>`

<img width="568" alt="screen shot 2018-07-14 at 16 48 09" src="https://user-images.githubusercontent.com/7708031/42726034-b71404de-8785-11e8-89df-d2c56f208505.png">
