### PR TITLE
Adding support/roles to run all versions of Fedora

### DIFF
--- a/installer/roles/ansible-service-broker-setup/meta/main.yml
+++ b/installer/roles/ansible-service-broker-setup/meta/main.yml
@@ -17,8 +17,7 @@ galaxy_info:
     - all
   - name: Fedora
     versions:
-    - 26
-    - 25
+    - all
 
   galaxy_tags:
   - aerogear

--- a/installer/roles/oc-cluster-up/meta/main.yml
+++ b/installer/roles/oc-cluster-up/meta/main.yml
@@ -17,8 +17,7 @@ galaxy_info:
     - all
   - name: Fedora
     versions:
-    - 26
-    - 25
+    - all
 
   galaxy_tags:
   - aerogear

--- a/installer/roles/template-service-broker-setup/meta/main.yml
+++ b/installer/roles/template-service-broker-setup/meta/main.yml
@@ -17,8 +17,7 @@ galaxy_info:
     - all
   - name: Fedora
     versions:
-    - 26
-    - 25
+    - all
 
   galaxy_tags:
   - aerogear


### PR DESCRIPTION
## Motivation
* Support all Fedora versions
* Issues: https://github.com/aerogear/mobile-core/issues/140 and https://github.com/aerogear/mobile-core/issues/110 and https://github.com/aerogear/mobile-docs/issues/345
 
## Description
Some roles are not covering the newer Fedora versions.

## Progress

- [x] Finished task
- [] TODO

## Additional Notes

To test it is required to try to install in a Fedora 27 and/or 28. 