### PR TITLE
fix(tech debt): Remove  option from ansible service broker

### DIFF
--- a/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
+++ b/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
@@ -33,8 +33,8 @@ if [[ ! -e $CERT_DIR ]]; then
     echo "Generating new self trusted certificate for cluster"
 	mkdir -p $CERT_DIR
     openssl req -nodes -x509 -newkey rsa:4096 -keyout $CERT_DIR/key.pem -out $CERT_DIR/cert.pem -days 365 -subj "/CN=asb-etcd.ansible-service-broker.svc"
-    openssl genrsa -out $CERT_DIR/MyClient1.key 2048 
-	openssl req -new -key $CERT_DIR/MyClient1.key -out $CERT_DIR/MyClient1.csr -subj "/CN=client" 
+    openssl genrsa -out $CERT_DIR/MyClient1.key 2048
+	openssl req -new -key $CERT_DIR/MyClient1.key -out $CERT_DIR/MyClient1.csr -subj "/CN=client"
 	openssl x509 -req -in $CERT_DIR/MyClient1.csr -CA $CERT_DIR/cert.pem -CAkey $CERT_DIR/key.pem -CAcreateserial -out $CERT_DIR/MyClient1.pem -days 1024
 fi
 
@@ -61,7 +61,6 @@ oc process -f "${TEMPLATE_LOCAL}" \
 -p BROKER_CLIENT_CERT="$BROKER_CLIENT_CERT" \
 -p BROKER_CLIENT_KEY="$BROKER_CLIENT_KEY" \
 -p NAMESPACE=${ANSIBLE_SERVICE_BROKER_NAMESPACE} \
--p AUTO_ESCALATE="true" \
 -p LAUNCH_APB_ON_BIND="${LAUNCH_APB_ON_BIND}" \
 ${TEMPLATE_VARS} | oc create -f -
 


### PR DESCRIPTION
## Motivation
Issue: https://github.com/aerogear/mobile-core/issues/14

## Description
Shows that the flag/param AUTO_ESCALATE="true" was added because the mobile was not appearing in the catalogue. However, I tested it locally in iOS env and all shows still working perfectly. 

## Progress

- [x] Finished task
- [] TODO

## Additional Notes

<img width="718" alt="screen shot 2018-07-26 at 07 30 48" src="https://user-images.githubusercontent.com/7708031/43245376-fb22f346-90a5-11e8-8673-ed9402082e3a.png">

<img width="969" alt="screen shot 2018-07-26 at 07 32 16" src="https://user-images.githubusercontent.com/7708031/43245401-0e9d1b7c-90a6-11e8-8cc4-e3b88a9995a7.png">
