### PR TITLE
fix(installer): Issue 205: Installer successfully terminates improperly when an error occurs in the Ansible script execution

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -456,7 +456,7 @@ function run_ansible_tasks() {
     spinnerStop $?
     install_with_success_msg "Mobile Services"
     info_msg "See the Mobile Services in your OpenShift Console. URL: https://${DEFAULT_CLUSTER_IP}:8443/console/"
-    info_msg "For information on how to enable TLS communication on your device to this cluster see https://docs.aerogear.org/aerogear/latest/getting-started.html#using-self-signed-certificates-in-mobile-apps"
+    info_msg "For information on how to enable TLS communication on your device to this cluster see https://docs.aerogear.org/external/installer/self-signed-cert.html"
   fi
 }
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -430,33 +430,34 @@ function run_ansible_tasks() {
     spinnerStart 'It may take few minutes ...'
     if [[ ${oc_version_comparison} -ne ${VER_LT} ]]; then
       install_with_success_msg "OpenShift client tool"
-      ansible-playbook installer/playbook.yml --skip-tags "install-oc" \
+      (ansible-playbook installer/playbook.yml --skip-tags "install-oc" \
       -e "dockerhub_username=${dockerhub_username}" \
       -e "dockerhub_password=${dockerhub_password}" \
       -e "dockerhub_tag=${dockerhub_tag}" \
       -e "dockerhub_org=${dockerhub_org}" \
       -e "cluster_public_ip=${cluster_ip}" \
-      -e "wildcard_dns_host=${wildcard_dns_host}" &>/dev/null
+      -e "wildcard_dns_host=${wildcard_dns_host}" 2>&1 | grep 'failed=0') &>/dev/null
     else
-      ansible-playbook installer/playbook.yml \'
+      (ansible-playbook installer/playbook.yml \'
       -e "dockerhub_username=${dockerhub_username}" \
       -e "dockerhub_password=${dockerhub_password}" \
       -e "dockerhub_tag=${dockerhub_tag}" \
       -e "dockerhub_org=${dockerhub_org}" \
       -e "cluster_public_ip=${cluster_ip}" \
       -e "wildcard_dns_host=${wildcard_dns_host}" \
-      -e "oc_install_parent_dir=${oc_install_dir}" &>/dev/null
+      -e "oc_install_parent_dir=${oc_install_dir}"  2>&1 | grep 'failed=0') &>/dev/null
+    fi
+    if [[ ${?} -ne 0 ]]; then
+      spinnerStop $?
+      echo -e  "${RED} ERROR: Unable to install the Mobile Services. ${RESET}"
+      echo -e  "${RED} ERROR: For further information use the --debug option to execute this installation. ${RESET}"
+      exit 1
     fi
     spinnerStop $?
+    install_with_success_msg "Mobile Services"
+    info_msg "See the Mobile Services in your OpenShift Console. URL: https://${DEFAULT_CLUSTER_IP}:8443/console/"
+    info_msg "For information on how to enable TLS communication on your device to this cluster see https://docs.aerogear.org/aerogear/latest/getting-started.html#using-self-signed-certificates-in-mobile-apps"
   fi
-  ansible_playbook_task=${?}; if [[ ${ansible_playbook_task} -ne 0 ]]; then
-    echo -e  "${RED} ERROR: Unable to install the Mobile Services. ${RESET}"
-    echo -e  "${RED} ERROR: For further information use the --debug option to execute this installation. ${RESET}"
-    exit 1
-  fi
-  install_with_success_msg "Mobile Services"
-  info_msg "See the Mobile Services in your OpenShift Console. URL: https://${DEFAULT_CLUSTER_IP}:8443/console/"
-  info_msg "For information on how to enable TLS communication on your device to this cluster see https://docs.aerogear.org/aerogear/latest/getting-started.html#using-self-signed-certificates-in-mobile-apps"
 }
 
 # Run all scripts to install after the checks


### PR DESCRIPTION
## Motivation
Issue https://github.com/aerogear/mobile-core/issues/205
## What
Fix to get the result of the ansible scripts 

## Why
To show the properly msg when it fails and the process was not executed in debug mode

## How
* Checking if the ansible has failures
* Fixing the place to get the result of the correct process

## Verification Steps
* Run it in a Fedora without the lib `libselinux-python` installed 
* See if it will finish with the ERROR and the info to re-run it with the --debug param to get further information as follows. ( Ref scenario Issue https://github.com/aerogear/mobile-core/issues/140 )

<img width="779" alt="screen shot 2018-08-19 at 19 28 42" src="https://user-images.githubusercontent.com/7708031/44311985-1338d800-a3e9-11e8-9fd0-2200837647cc.png">

OR

* Comment the `oc cluster up` validation into the install.sh script for don't check it (The code is [here](https://github.com/aerogear/mobile-core/blob/master/installer/install.sh#L310))
* Remove the registry configured in the docker

<img width="506" alt="screen shot 2018-08-19 at 20 15 53" src="https://user-images.githubusercontent.com/7708031/44312227-b8a17b00-a3ec-11e8-9ffe-a63262f6edc2.png">

* Executed the installer then it will fail in the `oc cluster up` ansible step
* Check if the error message as faced in the image above will appear 

OR

Run the installer with ANY setup which will be not checked and will make the ansible script fails. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task


## Additional Notes

This code implementation can be improved when we try to attend the RFE https://github.com/aerogear/mobile-core/issues/133
 

